### PR TITLE
Cosmetic: Conf options doc and names

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ The following environment variables can be used to configure the simulator and e
 
 - `NATS_HOST`: NATS server host
 - `NATS_PORT`: NATS server port
-- `SMTP_USERNAME`: the name of the email sender displayed next to the email
-- `TELESCOPE_NAMES`: list of telescope names if json format for example `'["jk15","zb08"]'`. List type variable
-- `EMAILS_TO`: List of email addresses to send reports to in json format `'["mail1@example.com","mail1@example.com"]'`. List type variable
+- `TELESCOPES`: List of telescope names included in HALina analysis.e.g. `'["jk15","zb08"]'` (JSON list)
+- `EMAILS_TO`: List of email addresses to send reports to `'["mail1@example.com","mail1@example.com"]'` (JSON list)
 - `SMTP_HOST`: Server SMTP host name
 - `SMTP_PORT`: Server SMTP port
-- `FROM_EMAIL`: Technical email to sending messages 
-- `FROM_NAME`: Display name for the email sender
-- `SMTP_PASSWORD`: Password to technical email 
+- `SMTP_USERNAME`: SMTP server username 
+- `SMTP_PASSWORD`: SMTP server user password  
+- `FROM_EMAIL`: Sent emails FROM field email address, e.g. `noreplay.example.com` 
+- `FROM_NAME`: Sent emails FROM field display name, e.g. `HALina`
 - `SEND_AT`: UTC time at which the data collection process will be started. It is integer number representing hour.
 
 Note. It is important that List type variables are wrapped in `' '`.
@@ -62,14 +62,16 @@ Example `.env` file:
 ```text
 NATS_HOST=localhost
 NATS_PORT=4222
-SMTP_HOST="smtp.gmail.com"
-SMTP_PORT=587
 
-TELESCOPE_NAMES='["jk15","zb08"]'
-EMAILS_TO='["mail1@example.com","mail1@example.com"]'
-FROM_EMAIL="example@email.com"
-FROM_NAME="Halina from OCM"
+TELESCOPES='["jk15","zb08"]'
+
+SMTP_HOST="smtp.example.com"
+SMTP_PORT=587
+SMTP_USERNAME="halina@example.com"
 SMTP_PASSWORD="abcdefg"
+EMAILS_TO='["mail1@example.com","mail1@example.com"]'
+FROM_EMAIL="noreplay@example.com"
+FROM_NAME="Halina"
 SEND_AT=14
 ```
 
@@ -82,7 +84,7 @@ It is also possible to set environment variables manually one by one.
 It is also possible to configure the application by providing variable values directly as command options. For example: 
 
 ```bash
-poetry run services TELESCOPE_NAMES='["jk15","zb08"]' NATS_PORT=4222
+poetry run services TELESCOPES='["jk15","zb08"]' NATS_PORT=4222
 ```
 
 ## Usage

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -45,7 +45,7 @@ class GlobalConfig:
     SMTP_HOST = "SMTP_HOST"
     SMTP_PORT = "SMTP_PORT"
     SMTP_USERNAME = "SMTP_USERNAME"
-    TELESCOPE_NAMES = "TELESCOPE_NAMES"
+    TELESCOPES = "TELESCOPES"
     EMAILS_TO = "EMAILS_TO"
     TIMEZONE = "TIMEZONE"
     FROM_EMAIL = "FROM_EMAIL"
@@ -57,7 +57,7 @@ class GlobalConfig:
         NATS_HOST: __ConfigVal("localhost", str),
         NATS_PORT: __ConfigVal(4222, int),
         SMTP_USERNAME: __ConfigVal([], str),
-        TELESCOPE_NAMES: __ConfigVal([], list),
+        TELESCOPES: __ConfigVal([], list),
         EMAILS_TO: __ConfigVal([], list),
         TIMEZONE: __ConfigVal(0, int),
         SMTP_HOST: __ConfigVal("smtp.gmail.com", str),
@@ -67,7 +67,7 @@ class GlobalConfig:
         SMTP_PASSWORD: __ConfigVal("", str),
         SEND_AT: __ConfigVal(14, int),  # at witch hour will be sent email
     }
-    __setters = [NATS_HOST, NATS_PORT, SMTP_USERNAME, TELESCOPE_NAMES, EMAILS_TO, TIMEZONE, SMTP_HOST, SMTP_PORT, FROM_EMAIL,
+    __setters = [NATS_HOST, NATS_PORT, SMTP_USERNAME, TELESCOPES, EMAILS_TO, TIMEZONE, SMTP_HOST, SMTP_PORT, FROM_EMAIL,
                  FROM_NAME, SMTP_PASSWORD, SEND_AT]
 
     @classmethod

--- a/src/halina/email_rapport_service.py
+++ b/src/halina/email_rapport_service.py
@@ -22,7 +22,7 @@ class EmailRapportService(Service):
         super().__init__()
         self._nats_messenger = Messenger()
         self._utc_offset: int = utc_offset
-        self._telescopes: List[str] = GlobalConfig.get(GlobalConfig.TELESCOPE_NAMES)
+        self._telescopes: List[str] = GlobalConfig.get(GlobalConfig.TELESCOPES)
         self._send_at_time = datetime.time(GlobalConfig.get(GlobalConfig.SEND_AT), 0)
 
     @staticmethod

--- a/src/halina/main.py
+++ b/src/halina/main.py
@@ -43,7 +43,7 @@ def read_configuration(**kwargs):
     set_single_setting(GlobalConfig.SMTP_USERNAME, kwargs)
     set_single_setting(GlobalConfig.SMTP_PASSWORD, kwargs)
     set_single_setting(GlobalConfig.FROM_NAME, kwargs)
-    set_single_setting(GlobalConfig.TELESCOPE_NAMES, kwargs, False)
+    set_single_setting(GlobalConfig.TELESCOPES, kwargs, False)
     set_single_setting(GlobalConfig.TIMEZONE, kwargs, False)
     set_single_setting(GlobalConfig.FROM_EMAIL, kwargs)
     set_single_setting(GlobalConfig.EMAILS_TO, kwargs, False)


### PR DESCRIPTION
Better wording of conf options doc.


Why `TELESCOPE_NAMES` -> `TELESCOPES`?

This is a list of telescopes (identified by names) for raport. `TELESCOPE_NAMES` would suggest that we are configuring names of the the telescopes.

